### PR TITLE
Fix for error TS2345 when running from docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /home/solend/app
 ENV NODE_OPTIONS=--max_old_space_size=4096
 
 # Only copy the package.json file to work directory
-COPY package.json ./
+COPY package.json package-lock.json ./
 # Install all Packages
 RUN npm install
 


### PR DESCRIPTION
Running from docker fails with the following error, without the lock file.

```
 > [8/8] RUN npm run build:                                                                                                                                                      
#13 0.323                                                                                                                                                                        
#13 0.323 > solend-liquidator@1.0.0 build                                                                                                                                        
#13 0.323 > rm -rf build/ && tsc -p tsconfig.json
#13 0.323 
#13 1.433 src/libs/pyth.ts(24,26): error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'Value'.
#13 1.433   Type 'undefined' is not assignable to type 'Value'.
```